### PR TITLE
register google search console.

### DIFF
--- a/2022/index.html
+++ b/2022/index.html
@@ -6,7 +6,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta name="description" content="">
         <meta name="keyword" content="TeraCoder,テラコーダー,てらこーだー,プログラミングコンテスト,京都産業大学,コンピュータ理工学部,情報理工学部,寺子屋">
-        <meta name="google-site-verification" content="Jvz850ttgpxhODOxnVe-dVkW2MvPaQ_qIgXpJKcg7c8" />
+        <meta name="google-site-verification" content="ZPI0qDG3xQrWc9GKCBGH_iygHKjgKvY8P0U1Gp1cvFc" />
         <meta name="author" content="TeraCoder運営スタッフ" />
         <meta name="copyright" content="Copyright (C) 2013-2022 TeraCoder運営スタッフ" />
         <meta name="format-detection" content="telephone=no" />


### PR DESCRIPTION
2022年版のティザーサイトが検索に引っかからないので，
新たにGoogle Search Consoleに登録し，所有権の確認用コードをindex.htmlに埋め込んだ．